### PR TITLE
Add less frequently used verbs as values

### DIFF
--- a/decisions-en/meeting-101(II).yml
+++ b/decisions-en/meeting-101(II).yml
@@ -71,7 +71,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/101(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2012-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2012-10-01
     message: |-
       accepted Recommendation CCTF 1 (2012), agreed to make it a CIPM recommendation and asked the BIPM Director to prepare a Draft Resolution for the 25th CGPM meeting and submit it to the CIPM bureau in March 2013.
@@ -325,7 +325,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2012-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2012-10-01
     message: |-
       authorized the BIPM Director to submit the draft protocol for "The BIPM Calibration Campaign in anticipation of the kilogram redefinition" to the CCM for review and provision of a recommendation to the CIPM.

--- a/decisions-en/meeting-102(II).yml
+++ b/decisions-en/meeting-102(II).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/102(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2013-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2013-10-01
     message: accepted the minutes of Session I of the 102nd meeting of the CIPM as
       a true record.
@@ -58,7 +58,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/102(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2013-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2013-10-01
     message: accepted the changes proposed by Dr May to the document "Criteria and
       Process for Election of CIPM Members". The revised version to be placed on the
@@ -286,7 +286,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/102(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2013-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2013-10-01
     message: accepted the principle that the BIPM should establish an NMR facility
       subject to the availability of support from a third party and asked the CIPM

--- a/decisions-en/meeting-103(I).yml
+++ b/decisions-en/meeting-103(I).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/103(I).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2014-03-01
     message: accepted the minutes of the 102nd meeting of the CIPM as a true record.
   actions: []
@@ -103,7 +103,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charged the CIPM Secretary to initiate by early April 2014 a second round
       of communication to Member States representatives and Directors of National
@@ -132,7 +132,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charged the CIPM Secretary to send a copy of the resignation document
       signed by the 16 members present at Session I of the 103rd meeting of the CIPM
@@ -147,7 +147,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charged the Working Group on CIPM Membership to come forward with proposed
       criteria and selection process of CC Presidents and good practices for the appointment
@@ -192,7 +192,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charged the BIPM to hold a meeting of NMI Directors in 2015 dedicated
       to the CIPM MRA review focusing on the benefits of the CIPM MRA, as well as
@@ -221,7 +221,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/103(I).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2014-03-01
     message: |-
       accepted the provisional timetable for the CGPM meeting and decided that the preparatory meeting on the dotation of the BIPM will take place on the morning of Monday 17 November 2014 (lab tours and presentations to follow in the afternoon).
@@ -344,7 +344,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charged S. Arlen and stem:["T"].stem:["J"]. Quinn to prepare notes on
       terminology to be forwarded to the CIPM and to be considered by the bureau at

--- a/decisions-en/meeting-103(II).yml
+++ b/decisions-en/meeting-103(II).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/103(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2014-11-01
     message: accepted the minutes of Session I of the 103rd meeting of the CIPM as
       a true record.
@@ -164,7 +164,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/103(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2014-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2014-11-01
     message: "accepted the following changes to the Consultative Committees:\n\n*
       CCPR\r\n** CMI (Czech Republic): Member\n** CMS/ITRI (Chinese Taipei): Observer\n**

--- a/decisions-en/meeting-104(I).yml
+++ b/decisions-en/meeting-104(I).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/104(I).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2015-I-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2015-03-01
     message: accepted the minutes of Session II of the 103rd meeting of the CIPM as
       a true record.
@@ -26,7 +26,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2015-I-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: elects
     date_effective: 2015-03-01
     message: elected Dr Inglis as President of the CIPM by acclamation.
   subject: The CIPM
@@ -38,7 +38,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2015-I-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: elects
     date_effective: 2015-03-01
     message: |-
       elected the following by secret ballot:

--- a/decisions-en/meeting-104(II).yml
+++ b/decisions-en/meeting-104(II).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/104(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2015-II-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2015-10-01
     message: accepted the minutes of Session I of the 104th meeting of the CIPM as
       a true record.

--- a/decisions-en/meeting-105.yml
+++ b/decisions-en/meeting-105.yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/105.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2016-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2016-10-01
     message: accepted the minutes of Session II of the 104th meeting of the CIPM as
       a true record.
@@ -452,7 +452,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/105.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2016-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2016-10-01
     message: |-
       accepted the following changes to the membership and observership of the Consultative Committees:

--- a/decisions-en/meeting-106.yml
+++ b/decisions-en/meeting-106.yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/106.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2017-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2017-10-01
     message: accepted the minutes of the 105th meeting of the CIPM as a true record.
   actions: []
@@ -158,7 +158,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2017-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2017-10-01
     message: authorized the CIPM President to convey its support for the publication
       of the final numerical values for the defining constants to the Task Group for
@@ -171,7 +171,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/106.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2017-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2017-10-01
     message: "accepted the revised Draft Resolution stem:[\"A\"] as presented at the
       106th meeting of the CIPM which included modifications:\n\n* to the wording
@@ -296,7 +296,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/106.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2017-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2017-10-01
     message: "accepted the following changes to the membership and observership of
       the Consultative Committees:\n\n* CCEM\n\n** NIS (Egypt) as an observer. \n*
@@ -460,7 +460,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/106.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2017-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2017-10-01
     message: accepted document CIPM/17-23.1 as its position on revision of the _International
       Vocabulary of Metrology_ (VIM).

--- a/decisions-en/meeting-107.yml
+++ b/decisions-en/meeting-107.yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/107.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2018-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2018-06-01
     message: accepted the minutes of the 106th meeting of the CIPM as a true record.
   actions: []
@@ -251,7 +251,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/107.html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2018-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2018-06-01
     message: accepted the proposal that GUM (Poland) and NIS (Egypt) should become
       observers at the CCL.

--- a/decisions-en/meeting-108(I).yml
+++ b/decisions-en/meeting-108(I).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/108(I).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-I-Decisions-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2019-03-01
     message: accepted the minutes of the 107th meeting of the CIPM as a true record.
   actions: []
@@ -39,7 +39,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-I-Decisions-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: elects
     date_effective: 2019-03-01
     message: elected Dr stem:["W"]. Louw as President of the CIPM by secret ballot.
   subject: The CIPM
@@ -51,7 +51,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-I-Decisions-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: elects
     date_effective: 2019-03-01
     message: |-
       elected the following by secret ballot:
@@ -214,7 +214,7 @@ resolutions:
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-I-Decisions-EN.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2019-03-01
     message: charged Dr stem:["T"]. Liew to draft terms of reference for the CIPM
       _ad hoc_ Working Group on the Reproducibility of Research Data and Related Topics

--- a/decisions-en/meeting-108(II).yml
+++ b/decisions-en/meeting-108(II).yml
@@ -12,7 +12,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/108(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-II-Decisions-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2019-10-01
     message: accepted the minutes of the first session of the 108th meeting of the
       CIPM as a true record.
@@ -373,7 +373,7 @@ resolutions:
   url: https://www.bipm.org/en/committees/cipm/meeting/108(II).html
   reference: https://www.bipm.org/utils/en/pdf/CIPM/CIPM2019-II-Decisions-EN.pdf
   considerations:
-  - type: acknowledging
+  - type: accepts
     date_effective: 2019-10-01
     message: "accepted the following changes to the membership and observership of
       the Consultative Committees:\n\n* CCEM\n\n** CMI (Czechia) as a member\n* CCM\n\n**

--- a/decisions-fr/meeting-101(I).yml
+++ b/decisions-fr/meeting-101(I).yml
@@ -509,7 +509,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2012-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2012-06-01
     message: autorise le directeur du BIPM à signer le protocole d'accord entre le
       BIPM et l'AIEA.

--- a/decisions-fr/meeting-101(II).yml
+++ b/decisions-fr/meeting-101(II).yml
@@ -327,7 +327,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2012-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2012-10-01
     message: |-
       autorise le directeur du BIPM à soumettre au CCM le projet de protocole concernant la campagne d'étalonnages du BIPM en vue de la redéfinition du kilogramme afin que le CCM l'examine et fasse une recommandation au CIPM.

--- a/decisions-fr/meeting-102(II).yml
+++ b/decisions-fr/meeting-102(II).yml
@@ -162,7 +162,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2013-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2013-10-01
     message: autorise le directeur du BIPM à appliquer les normes IPSAS 28, IPSAS
       29 et IPSAS 30 sur les instruments financiers pour les états financiers de 2013

--- a/decisions-fr/meeting-103(I).yml
+++ b/decisions-fr/meeting-103(I).yml
@@ -103,7 +103,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2014-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charge le secrétaire du CIPM de préparer pour le début du mois d'avril
       2014 un second courrier adressé aux représentants des États Membres et aux directeurs
@@ -148,7 +148,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2014-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2014-03-01
     message: charge le Groupe de travail _ad hoc_ sur les règles et les principes
       relatifs à la composition du CIPM de soumettre à l'approbation du CIPM, lors

--- a/decisions-fr/meeting-104(I).yml
+++ b/decisions-fr/meeting-104(I).yml
@@ -310,7 +310,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2015-I-FR.pdf
   considerations: []
   actions:
-  - type: encourages
+  - type: elects
     date_effective: 2015-03-01
     message: propose M. Buzoianu pour représenter le BIPM au Groupe de travail 2 sur
       le VIM du Comité commun pour les guides en métrologie (JCGM).
@@ -323,7 +323,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2015-I-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2015-03-01
     message: charge le BIPM de contacter l'ensemble des directeurs des laboratoires
       nationaux de métrologie pour solliciter leurs contributions et leur participation

--- a/decisions-fr/meeting-106.yml
+++ b/decisions-fr/meeting-106.yml
@@ -166,7 +166,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2017-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: authorizes
     date_effective: 2017-10-01
     message: autorise le président du CIPM à transmettre au _Task Group on Fundamental
       Constants_ de CODATA son accord concernant la publication des valeurs numériques
@@ -443,7 +443,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2017-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2017-10-01
     message: charge le président du CIPM d'inviter chacune des organisations régionales
       de métrologie à envoyer un ou deux représentants à la prochaine réunion des

--- a/decisions-fr/meeting-108(I).yml
+++ b/decisions-fr/meeting-108(I).yml
@@ -204,7 +204,7 @@ resolutions:
   reference: https://www.bipm.org/utils/fr/pdf/CIPM/CIPM2019-I-Decisions-FR.pdf
   considerations: []
   actions:
-  - type: appoints
+  - type: charges
     date_effective: 2019-03-01
     message: charge stem:["T"]. Liew de rédiger les termes de référence du Groupe
       de travail _ad hoc_ du CIPM sur la reproductibilité des données de recherches

--- a/meetings-en/meeting-1964.yml
+++ b/meetings-en/meeting-1964.yml
@@ -14,7 +14,7 @@ resolutions:
     degree: unanimous
     message: The Comité International des Poids et Mesures,
   considerations:
-  - type: acknowledging
+  - type: empowers
     date_effective: 1964-01-01
     message: *empowered* by cgpm-resolution:en/12/5[Resolution 5] of the 12th Conférence
       Générale des Poids et Mesures to name atomic or molecular frequency standards

--- a/meetings-en/meeting-1988.yml
+++ b/meetings-en/meeting-1988.yml
@@ -14,7 +14,7 @@ resolutions:
     degree: unanimous
     message: The Comité International des Poids et Mesures
   considerations:
-  - type: recognizing
+  - type: acting
     date_effective: 1988-01-01
     message: '*acting* in accordance with instructions given in Resolution 6 of the 18th
       Conférence Générale des Poids et Mesures concerning the forthcoming adjustment
@@ -54,7 +54,7 @@ resolutions:
     message: that from this same date all other laboratories adjust the
       value of their laboratory reference standards to agree with the new adopted
       value,
-  - type: calls upon
+  - type: draws the attention
     date_effective: 1988-01-01
     message: '*draws the attention* of laboratories to the fact that the new value is
       greater by stem:[3.9 "GHz"/"V"], or about 8 parts in stem:[10^(6)], than the
@@ -70,7 +70,7 @@ resolutions:
     degree: unanimous
     message: The Comité International des Poids et Mesures,
   considerations:
-  - type: recognizing
+  - type: acting
     date_effective: 1988-01-01
     message: "*acting* in accordance with instructions given in cgpm-resolution:en/18/6[Resolution
       6] of the 18th Conférence Générale des Poids et Mesures concerning the forthcoming

--- a/meetings-en/meeting-1989.yml
+++ b/meetings-en/meeting-1989.yml
@@ -14,7 +14,7 @@ resolutions:
     degree: unanimous
     message: The Comité International des Poids et Mesures (CIPM)
   considerations:
-  - type: recognizing
+  - type: acting
     date_effective: 1989-01-01
     message: |-
       acting in accordance with cgpm-resolution:en/18/7[Resolution 7] of the 18th Conférence Générale des Poids et Mesures (1987) has adopted the International Temperature Scale of 1990 ( https://www.bipm.org/en/publications/its-90.html[ITS-90]) to supersede the International Practical Temperature Scale of 1968 (IPTS-68).

--- a/meetings-fr/meeting-1964.yml
+++ b/meetings-fr/meeting-1964.yml
@@ -17,13 +17,13 @@ resolutions:
 
       Le Comité international des poids et mesures,
   considerations:
-  - type: acknowledging
+  - type: empowers
     date_effective: 1964-01-01
     message: habilité par la Résolution 5 de la Douzième Conférence générale des poids
       et mesures à désigner les étalons atomiques ou moléculaires de fréquence à employer
       temporairement pour les mesures physiques de temps,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1964-01-01
     message: déclare que l'étalon à employer est la transition entre les niveaux hyperfins
       stem:[F = 4], stem:[M = 0] et stem:[F = 3], _M =_ 0 de l'état fondamental ^2^S~1/2~

--- a/meetings-fr/meeting-1967.yml
+++ b/meetings-fr/meeting-1967.yml
@@ -24,7 +24,7 @@ resolutions:
       générale des poids et mesures (1960) peut prêter à des interprétations divergentes
       dans son application à l'unité de masse,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1967-01-01
     message: 'déclare que les dispositions de la Résolution 12 de la onzième Conférence
       générale s''appliquent dans le cas du kilogramme de la façon suivante : les

--- a/meetings-fr/meeting-1969.yml
+++ b/meetings-fr/meeting-1969.yml
@@ -24,7 +24,7 @@ resolutions:
       Conférence générale des poids et mesures (1960), concernant le Système international
       d'unités, a suscité des discussions sur certaines dénominations,
   actions:
-  - type: decides
+  - type: declares
     date_effective: 1969-01-01
     message: |-
       déclare

--- a/meetings-fr/meeting-1988.yml
+++ b/meetings-fr/meeting-1988.yml
@@ -17,7 +17,7 @@ resolutions:
 
       Le Comité international des poids et mesures,
   considerations:
-  - type: having / having regard
+  - type: acting
     date_effective: 1988-01-01
     message: agissant conformément aux instructions données dans la Résolution 6 de
       la 18^e^ Conférence générale des poids et mesures concernant l'ajustement prévu
@@ -59,7 +59,7 @@ resolutions:
     message: recommande qu'à partir de cette même date tous les autres laboratoires
       ajustent la valeur de leurs étalons de référence pour la mettre en accord avec
       cette nouvelle valeur,
-  - type: calls upon
+  - type: draws the attention
     date_effective: 1988-01-01
     message: attire l'attention des laboratoires sur le fait que la nouvelle valeur
       est supérieure de stem:[3","9 "GHz"/"V"], soit approximativement stem:[8 * 10^(-6)]
@@ -78,7 +78,7 @@ resolutions:
 
       Le Comité international des poids et mesures,
   considerations:
-  - type: having / having regard
+  - type: acting
     date_effective: 1988-01-01
     message: "*agissant* conformément aux instructions données dans la cgpm-resolution:fr/18/6[Résolution
       6] de la 18^e^ Conférence générale des poids et mesures concernant l'ajustement

--- a/meetings-fr/meeting-2003.yml
+++ b/meetings-fr/meeting-2003.yml
@@ -37,7 +37,7 @@ resolutions:
       de radiations recommandées, mesures qui conduisent à une réduction considérable
       de l'incertitude ;
   actions:
-  - type: encourages
+  - type: proposes
     date_effective: 2003-01-01
     message: |-
       *propose* que la liste des radiations recommandées soit révisée pour inclure :


### PR DESCRIPTION
As requested in https://github.com/metanorma/cipm-resolutions/issues/4, less frequently used verbs are added as values in CIPM .yml files.